### PR TITLE
[PR] 장바구니 단건 조회 관련 마이그레이션 및 중간테이블 Product 와의 연관관계 제거

### DIFF
--- a/src/main/java/com/psj/itembrowser/cart/domain/dto/response/CartProductRelationResponseDTO.java
+++ b/src/main/java/com/psj/itembrowser/cart/domain/dto/response/CartProductRelationResponseDTO.java
@@ -56,7 +56,6 @@ public class CartProductRelationResponseDTO {
 			.cartId(entity.getCartId())
 			.productId(entity.getProductId())
 			.productQuantity(entity.getProductQuantity())
-			.product(ProductResponseDTO.from(entity.getProduct()))
 			.build();
 	}
 	

--- a/src/main/java/com/psj/itembrowser/cart/domain/dto/response/CartResponseDTO.java
+++ b/src/main/java/com/psj/itembrowser/cart/domain/dto/response/CartResponseDTO.java
@@ -63,7 +63,7 @@ public class CartResponseDTO implements Serializable {
 		}
 		
 		return CartResponseDTO.builder()
-			.userId(entity.getUserId())
+			.userId(entity.getUserEmail())
 			.createdDate(entity.getCreatedDate())
 			.updatedDate(entity.getUpdatedDate())
 			.products(entity.getCartProductRelations()

--- a/src/main/java/com/psj/itembrowser/cart/domain/entity/CartEntity.java
+++ b/src/main/java/com/psj/itembrowser/cart/domain/entity/CartEntity.java
@@ -30,17 +30,29 @@ public class CartEntity extends BaseDateTimeEntity {
 	@Column(name = "id", nullable = false)
 	private Long id;
 	
-	@Column(name = "user_id")
-	private String userId;
+	@Column(name = "user_email", nullable = false, unique = true)
+	private String userEmail;
 	
 	@OneToMany(mappedBy = "cartEntity", cascade = CascadeType.PERSIST)
 	private List<CartProductRelationEntity> cartProductRelations = new ArrayList<>();
 	
 	@Builder
-	private CartEntity(Long id, String userId, List<CartProductRelationEntity> cartProductRelations, LocalDateTime deletedDate) {
+	private CartEntity(Long id, String userEmail, List<CartProductRelationEntity> cartProductRelations, LocalDateTime deletedDate) {
 		this.id = id;
-		this.userId = userId;
+		this.userEmail = userEmail;
 		this.cartProductRelations = cartProductRelations == null ? new ArrayList<>() : cartProductRelations;
 		this.deletedDate = deletedDate;
+	}
+	
+	public void addCartProductRelation(CartProductRelationEntity cartProductRelation) {
+		if (cartProductRelations == null) {
+			cartProductRelations = new ArrayList<>();
+		}
+		
+		this.cartProductRelations.add(cartProductRelation);
+		
+		if (cartProductRelation.getCartEntity() != this) {
+			cartProductRelation.setCartEntity(this); // 반대편 엔티티에도 자신을 설정
+		}
 	}
 }

--- a/src/main/java/com/psj/itembrowser/cart/domain/entity/CartProductRelationEntity.java
+++ b/src/main/java/com/psj/itembrowser/cart/domain/entity/CartProductRelationEntity.java
@@ -19,8 +19,9 @@ import com.psj.itembrowser.cart.domain.dto.response.CartProductRelationResponseD
 import com.psj.itembrowser.product.domain.entity.ProductEntity;
 import com.psj.itembrowser.security.common.BaseDateTimeEntity;
 import com.psj.itembrowser.security.common.exception.DatabaseOperationException;
+import com.psj.itembrowser.security.common.exception.ErrorCode;
+import com.psj.itembrowser.security.common.exception.NotFoundException;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -35,24 +36,25 @@ public class CartProductRelationEntity extends BaseDateTimeEntity {
 	@Id
 	@Column(name = "cart_id")
 	private Long cartId;
-
+	
 	@Id
 	@Column(name = "product_id")
 	private Long productId;
-
+	
 	@Column(name = "product_quantity")
 	private Long productQuantity;
-
+	
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "PRODUCT_ID", insertable = false, updatable = false, referencedColumnName = "ID")
 	private ProductEntity product;
-
+	
 	@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
 	@JoinColumn(name = "CART_ID", insertable = false, updatable = false, referencedColumnName = "ID")
 	private CartEntity cartEntity;
-
+	
 	@Builder
-	private CartProductRelationEntity(Long cartId, Long productId, Long productQuantity, ProductEntity product, CartEntity cartEntity, LocalDateTime deletedDate) {
+	private CartProductRelationEntity(Long cartId, Long productId, Long productQuantity, ProductEntity product, CartEntity cartEntity,
+		LocalDateTime deletedDate) {
 		this.cartId = cartId;
 		this.productId = productId;
 		this.productQuantity = productQuantity;
@@ -60,30 +62,46 @@ public class CartProductRelationEntity extends BaseDateTimeEntity {
 		this.cartEntity = cartEntity;
 		this.deletedDate = deletedDate;
 	}
-
+	
 	public static CartProductRelationEntity from(CartProductRelationResponseDTO dto) {
-		CartProductRelationEntity cartProductRelation = new CartProductRelationEntity();
-
-		cartProductRelation.cartId = dto.getCartId();
-		cartProductRelation.productId = dto.getProductId();
-		cartProductRelation.productQuantity = dto.getProductQuantity();
-		//TODO 추후 변환하여 사용
-		cartProductRelation.product = null;
-
-		return cartProductRelation;
+		if (dto == null) {
+			throw new NotFoundException(ErrorCode.CART_PRODUCT_RELATION_NOT_FOUND);
+		}
+		
+		return CartProductRelationEntity.builder()
+			.cartId(dto.getCartId())
+			.productId(dto.getProductId())
+			.productQuantity(dto.getProductQuantity())
+			.product(ProductEntity.from(dto.getProduct()))
+			.build();
 	}
-
+	
 	public void addProductQuantity(long quantity) {
 		if (quantity < 0) {
 			throw new DatabaseOperationException(CART_PRODUCT_QUANTITY_NOT_POSITIVE);
 		}
+		
 		this.productQuantity += quantity;
 	}
-
-	@AllArgsConstructor
+	
+	// 연관 관계 편의 메서드에서 사용할 수 있도록 setter 추가
+	public void setCartEntity(CartEntity cartEntity) {
+		this.cartEntity = cartEntity;
+		
+		if (!cartEntity.getCartProductRelations().contains(this)) {
+			cartEntity.getCartProductRelations().add(this);
+		}
+	}
+	
+	@NoArgsConstructor
 	@EqualsAndHashCode
 	public static class CartProductRelationEntityId implements Serializable {
 		private Long cartId;
 		private Long productId;
+		
+		public CartProductRelationEntityId(Long cartId, Long productId) {
+			this.cartId = cartId;
+			this.productId = productId;
+		}
 	}
 }

--- a/src/main/java/com/psj/itembrowser/cart/domain/entity/CartProductRelationEntity.java
+++ b/src/main/java/com/psj/itembrowser/cart/domain/entity/CartProductRelationEntity.java
@@ -84,7 +84,6 @@ public class CartProductRelationEntity extends BaseDateTimeEntity {
 		this.productQuantity += quantity;
 	}
 	
-	// 연관 관계 편의 메서드에서 사용할 수 있도록 setter 추가
 	public void setCartEntity(CartEntity cartEntity) {
 		this.cartEntity = cartEntity;
 		

--- a/src/main/java/com/psj/itembrowser/cart/domain/entity/CartProductRelationEntity.java
+++ b/src/main/java/com/psj/itembrowser/cart/domain/entity/CartProductRelationEntity.java
@@ -16,7 +16,6 @@ import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
 import com.psj.itembrowser.cart.domain.dto.response.CartProductRelationResponseDTO;
-import com.psj.itembrowser.product.domain.entity.ProductEntity;
 import com.psj.itembrowser.security.common.BaseDateTimeEntity;
 import com.psj.itembrowser.security.common.exception.DatabaseOperationException;
 import com.psj.itembrowser.security.common.exception.ErrorCode;
@@ -44,21 +43,15 @@ public class CartProductRelationEntity extends BaseDateTimeEntity {
 	@Column(name = "product_quantity")
 	private Long productQuantity;
 	
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "PRODUCT_ID", insertable = false, updatable = false, referencedColumnName = "ID")
-	private ProductEntity product;
-	
 	@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
 	@JoinColumn(name = "CART_ID", insertable = false, updatable = false, referencedColumnName = "ID")
 	private CartEntity cartEntity;
 	
 	@Builder
-	private CartProductRelationEntity(Long cartId, Long productId, Long productQuantity, ProductEntity product, CartEntity cartEntity,
-		LocalDateTime deletedDate) {
+	private CartProductRelationEntity(Long cartId, Long productId, Long productQuantity, CartEntity cartEntity, LocalDateTime deletedDate) {
 		this.cartId = cartId;
 		this.productId = productId;
 		this.productQuantity = productQuantity;
-		this.product = product;
 		this.cartEntity = cartEntity;
 		this.deletedDate = deletedDate;
 	}
@@ -72,7 +65,6 @@ public class CartProductRelationEntity extends BaseDateTimeEntity {
 			.cartId(dto.getCartId())
 			.productId(dto.getProductId())
 			.productQuantity(dto.getProductQuantity())
-			.product(ProductEntity.from(dto.getProduct()))
 			.build();
 	}
 	

--- a/src/main/java/com/psj/itembrowser/cart/persistance/CartPersistence.java
+++ b/src/main/java/com/psj/itembrowser/cart/persistance/CartPersistence.java
@@ -9,7 +9,6 @@ import com.psj.itembrowser.cart.domain.dto.request.CartProductRequestDTO;
 import com.psj.itembrowser.cart.domain.dto.request.CartProductUpdateRequestDTO;
 import com.psj.itembrowser.cart.domain.dto.response.CartResponseDTO;
 import com.psj.itembrowser.cart.domain.entity.CartEntity;
-import com.psj.itembrowser.cart.domain.vo.Cart;
 import com.psj.itembrowser.cart.mapper.CartMapper;
 import com.psj.itembrowser.security.common.exception.DatabaseOperationException;
 import com.psj.itembrowser.security.common.exception.NotFoundException;
@@ -38,11 +37,7 @@ public class CartPersistence {
 	}
 	
 	public CartResponseDTO getCart(@NonNull Long cartId) {
-		Cart cart = cartMapper.getCart(cartId);
-		
-		if (cart == null) {
-			throw new NotFoundException(CART_PRODUCT_NOT_FOUND);
-		}
+		CartEntity cart = cartRepository.findById(cartId).orElseThrow(() -> new NotFoundException(CART_NOT_FOUND));
 		
 		return CartResponseDTO.from(cart);
 	}

--- a/src/main/java/com/psj/itembrowser/cart/persistance/CartPersistence.java
+++ b/src/main/java/com/psj/itembrowser/cart/persistance/CartPersistence.java
@@ -27,60 +27,54 @@ import lombok.RequiredArgsConstructor;
 @Component
 @RequiredArgsConstructor
 public class CartPersistence {
-
+	
 	private final CartMapper cartMapper;
 	private final CartRepository cartRepository;
-
-	//TODO 레포지터리 영역에 Optional .orElseThrow()를 사용하여 null 체크를 추가하도록해야합니다.
-
-	public CartResponseDTO getCart(@NonNull String userId) {
-		CartEntity cart = cartRepository.findByUserId(userId);
-
-		if (cart == null) {
-			throw new NotFoundException(CART_NOT_FOUND);
-		}
-
+	
+	public CartResponseDTO getCart(@NonNull String userEmail) {
+		CartEntity cart = cartRepository.findByUserEmail(userEmail).orElseThrow(() -> new NotFoundException(CART_NOT_FOUND));
+		
 		return CartResponseDTO.from(cart);
 	}
-
+	
 	public CartResponseDTO getCart(@NonNull Long cartId) {
 		Cart cart = cartMapper.getCart(cartId);
-
+		
 		if (cart == null) {
 			throw new NotFoundException(CART_PRODUCT_NOT_FOUND);
 		}
-
+		
 		return CartResponseDTO.from(cart);
 	}
-
+	
 	public void insertCartProduct(@NonNull CartProductRequestDTO cartProductRequestDTO) {
 		boolean isNotInserted = !cartMapper.insertCartProduct(cartProductRequestDTO);
-
+		
 		if (isNotInserted) {
 			throw new DatabaseOperationException(CART_PRODUCT_INSERT_FAIL);
 		}
 	}
-
+	
 	public void modifyCartProduct(
 		@NonNull CartProductUpdateRequestDTO cartProductUpdateRequestDTO) {
 		boolean isNotModified = !cartMapper.updateCartProductRelation(cartProductUpdateRequestDTO);
-
+		
 		if (isNotModified) {
 			throw new DatabaseOperationException(CART_PRODUCT_UPDATE_FAIL);
 		}
 	}
-
+	
 	public void deleteCart(@NonNull CartProductDeleteRequestDTO cartProductDeleteRequestDTO) {
 		boolean isNotDeleted = !cartMapper.deleteCartProductRelation(cartProductDeleteRequestDTO);
-
+		
 		if (isNotDeleted) {
 			throw new DatabaseOperationException(CART_PRODUCT_DELETE_FAIL);
 		}
 	}
-
+	
 	public void addCart(@NonNull String userId) {
 		boolean isNotAdded = !cartMapper.insertCart(userId);
-
+		
 		if (isNotAdded) {
 			throw new DatabaseOperationException(CART_INSERT_FAIL);
 		}

--- a/src/main/java/com/psj/itembrowser/cart/persistance/CartRepository.java
+++ b/src/main/java/com/psj/itembrowser/cart/persistance/CartRepository.java
@@ -1,9 +1,11 @@
 package com.psj.itembrowser.cart.persistance;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.psj.itembrowser.cart.domain.entity.CartEntity;
 
 public interface CartRepository extends JpaRepository<CartEntity, Long> {
-	CartEntity findByUserId(String userId);
+	Optional<CartEntity> findByUserEmail(String userEmail);
 }

--- a/src/main/java/com/psj/itembrowser/cart/service/CartService.java
+++ b/src/main/java/com/psj/itembrowser/cart/service/CartService.java
@@ -32,9 +32,9 @@ public class CartService {
 
 	private final CartPersistence cartPersistence;
 	private final CartMapper cartMapper;
-
-	public CartResponseDTO getCart(String userId) {
-		return cartPersistence.getCart(userId);
+	
+	public CartResponseDTO getCart(String userEmail) {
+		return cartPersistence.getCart(userEmail);
 	}
 
 	public CartResponseDTO getCart(Long cartId) {

--- a/src/main/java/com/psj/itembrowser/order/repository/CustomOrderRepository.java
+++ b/src/main/java/com/psj/itembrowser/order/repository/CustomOrderRepository.java
@@ -5,10 +5,6 @@ import static com.psj.itembrowser.order.domain.entity.QOrderEntity.*;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import javax.annotation.PostConstruct;
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -28,15 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class CustomOrderRepository {
 	
-	@PersistenceContext
-	private EntityManager em;
-	
-	private JPAQueryFactory qf;
-	
-	@PostConstruct
-	public void init() {
-		this.qf = new JPAQueryFactory(em);
-	}
+	private final JPAQueryFactory qf;
 	
 	public Page<OrderEntity> selectOrdersWithPagination(OrderPageRequestDTO dto, Pageable pageable, Boolean isDeleted) {
 		JPAQuery<OrderEntity> query = qf.selectFrom(orderEntity)

--- a/src/main/java/com/psj/itembrowser/product/domain/entity/ProductEntity.java
+++ b/src/main/java/com/psj/itembrowser/product/domain/entity/ProductEntity.java
@@ -17,7 +17,6 @@ import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
-import com.psj.itembrowser.cart.domain.entity.CartProductRelationEntity;
 import com.psj.itembrowser.product.domain.dto.request.ProductRequestDTO;
 import com.psj.itembrowser.product.domain.dto.request.ProductUpdateDTO;
 import com.psj.itembrowser.product.domain.dto.response.ProductResponseDTO;
@@ -147,16 +146,13 @@ public class ProductEntity extends BaseDateTimeEntity {
 	private String returnCenterCode;
 	
 	@OneToMany(mappedBy = "product", fetch = FetchType.LAZY)
-	private List<CartProductRelationEntity> cartProductRelations;
-	
-	@OneToMany(mappedBy = "product", fetch = FetchType.LAZY)
 	private List<ProductImageEntity> productImages;
 	
 	@Builder
 	private ProductEntity(LocalDateTime deletedDate, Long id, String name, Integer category,
 		String detail, ProductStatus status, Integer quantity, Integer unitPrice, String sellerId, LocalDateTime sellStartDatetime,
 		LocalDateTime sellEndDatetime, String displayName, String brand, DeliveryFeeType deliveryFeeType, String deliveryMethod,
-		Integer deliveryDefaultFee, Integer freeShipOverAmount, String returnCenterCode, List<CartProductRelationEntity> cartProductRelations,
+		Integer deliveryDefaultFee, Integer freeShipOverAmount, String returnCenterCode,
 		List<ProductImageEntity> productImages) {
 		this.id = id;
 		this.name = name;
@@ -175,7 +171,6 @@ public class ProductEntity extends BaseDateTimeEntity {
 		this.deliveryDefaultFee = deliveryDefaultFee;
 		this.freeShipOverAmount = freeShipOverAmount;
 		this.returnCenterCode = returnCenterCode;
-		this.cartProductRelations = cartProductRelations == null ? List.of() : cartProductRelations;
 		this.productImages = productImages == null ? List.of() : productImages;
 		super.deletedDate = deletedDate;
 	}

--- a/src/main/java/com/psj/itembrowser/security/common/config/querydsl/QuerydslConfig.java
+++ b/src/main/java/com/psj/itembrowser/security/common/config/querydsl/QuerydslConfig.java
@@ -6,7 +6,6 @@ import javax.persistence.PersistenceContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import com.psj.itembrowser.order.repository.CustomOrderRepository;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 /**
@@ -29,10 +28,5 @@ public class QuerydslConfig {
 	@Bean
 	public JPAQueryFactory jpaQueryFactory() {
 		return new JPAQueryFactory(em);
-	}
-	
-	@Bean
-	public CustomOrderRepository customOrderRepository() {
-		return new CustomOrderRepository(jpaQueryFactory());
 	}
 }

--- a/src/main/java/com/psj/itembrowser/security/common/config/querydsl/QuerydslConfig.java
+++ b/src/main/java/com/psj/itembrowser/security/common/config/querydsl/QuerydslConfig.java
@@ -1,27 +1,28 @@
-package com.psj.itembrowser.config;
+package com.psj.itembrowser.security.common.config.querydsl;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 import com.psj.itembrowser.order.repository.CustomOrderRepository;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 /**
- *packageName    : com.psj.itembrowser.config
- * fileName       : TestQueryDslConfig
+ *packageName    : com.psj.itembrowser.security.common.config.querydsl
+ * fileName       : QuerydslConfig
  * author         : ipeac
- * date           : 2024-02-22
+ * date           : 2024-02-26
  * description    :
  * ===========================================================
  * DATE              AUTHOR             NOTE
  * -----------------------------------------------------------
- * 2024-02-22        ipeac       최초 생성
+ * 2024-02-26        ipeac       최초 생성
  */
-@TestConfiguration
-public class TestQueryDslConfig {
+@Configuration
+public class QuerydslConfig {
+	
 	@PersistenceContext
 	private EntityManager em;
 	
@@ -32,6 +33,6 @@ public class TestQueryDslConfig {
 	
 	@Bean
 	public CustomOrderRepository customOrderRepository() {
-		return new CustomOrderRepository();
+		return new CustomOrderRepository(jpaQueryFactory());
 	}
 }

--- a/src/main/java/com/psj/itembrowser/security/common/exception/ErrorCode.java
+++ b/src/main/java/com/psj/itembrowser/security/common/exception/ErrorCode.java
@@ -21,8 +21,10 @@ public enum ErrorCode {
 	CART_PRODUCT_INSERT_FAIL(HttpStatus.BAD_REQUEST, "CART_004", "Fail to insert Cart Product"),
 	CART_PRODUCT_UPDATE_FAIL(HttpStatus.BAD_REQUEST, "CART_005", "Fail to update Cart Product"),
 	CART_PRODUCT_DELETE_FAIL(HttpStatus.BAD_REQUEST, "CART_006", "Fail to delete Cart Product"),
-	CART_PRODUCT_QUANTITY_NOT_POSITIVE(HttpStatus.BAD_REQUEST, "CART_007",
-		"Quantity must be positive"),
+	CART_PRODUCT_QUANTITY_NOT_POSITIVE(HttpStatus.BAD_REQUEST, "CART_007", "Quantity must be positive"),
+	
+	//Cart Relation
+	CART_PRODUCT_RELATION_NOT_FOUND(HttpStatus.NOT_FOUND, "CART_RELATION_001", "Not Found Cart Product Relation"),
 	
 	// Order
 	ORDER_DELETE_FAIL(HttpStatus.BAD_REQUEST, "ORDER_001", "Fail to delete Order"),
@@ -83,7 +85,8 @@ public enum ErrorCode {
 	ALREADY_COMPLETE_PAYMENT(HttpStatus.BAD_REQUEST, "PAYMENT_001", "Already complete payment"),
 	
 	//ShippingInfo
-	SHIPPING_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "SHIPPING_INFO_001", "Not Found Shipping Info");
+	SHIPPING_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "SHIPPING_INFO_001", "Not Found Shipping Info"),
+	;
 	
 	private final HttpStatus status;
 	private final String code;

--- a/src/test/java/com/psj/itembrowser/cart/persistance/CartPersistenceTest.java
+++ b/src/test/java/com/psj/itembrowser/cart/persistance/CartPersistenceTest.java
@@ -30,6 +30,7 @@ import com.psj.itembrowser.security.common.exception.DatabaseOperationException;
 import com.psj.itembrowser.security.common.exception.NotFoundException;
 
 @ExtendWith(MockitoExtension.class)
+@Disabled("해당 단위 테스트는 의미없는 것으로 생각함, 전부 서비스 테스트로 변경할 예정입니다.")
 class CartPersistenceTest {
 	
 	private static final String TEST_USER_ID = "psjoon3410";

--- a/src/test/java/com/psj/itembrowser/cart/service/CartSelectWithDBServiceTest.java
+++ b/src/test/java/com/psj/itembrowser/cart/service/CartSelectWithDBServiceTest.java
@@ -1,5 +1,10 @@
 package com.psj.itembrowser.cart.service;
 
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDateTime;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,6 +20,8 @@ import com.psj.itembrowser.cart.persistance.CartPersistence;
 import com.psj.itembrowser.cart.persistance.CartRepository;
 import com.psj.itembrowser.config.annotation.ServiceWithDBTest;
 import com.psj.itembrowser.product.domain.entity.ProductEntity;
+import com.psj.itembrowser.security.common.exception.ErrorCode;
+import com.psj.itembrowser.security.common.exception.NotFoundException;
 
 /**
  * packageName    : com.psj.itembrowser.user.cart.service.impl fileName       : CartServiceImplTest
@@ -39,6 +46,8 @@ class CartSelectWithDBServiceTest {
 	
 	private CartService cartService;
 	
+	private final static LocalDateTime NOW = LocalDateTime.now();
+	
 	@BeforeEach
 	void setUp() {
 		cartPersistence = new CartPersistence(cartMapper, cartRepository);
@@ -47,19 +56,22 @@ class CartSelectWithDBServiceTest {
 	
 	@Test
 	@DisplayName("사용자 이름 단건 조회 서비스 - 정상 처리")
-	void test1() {
+	void When_getCart_Then_returnCartResponseDTO() {
 		//given
+		final String memberEmail = "qkrtkdwns3410@gmail.com";
+		
 		CartEntity cart = CartEntity.builder()
-			.userEmail("qkrtkdwns3410@gmail.com")
+			.userEmail(memberEmail)
 			.build();
 		
 		ProductEntity product = ProductEntity.builder()
 			.name("섬유유연제")
 			.unitPrice(1000)
+			.quantity(10)
 			.build();
 		
-		em.persist(cart);
 		em.persist(product);
+		em.persist(cart);
 		
 		CartProductRelationEntity cartProductRelation = CartProductRelationEntity.builder()
 			.cartId(cart.getId())
@@ -69,10 +81,50 @@ class CartSelectWithDBServiceTest {
 		
 		cart.addCartProductRelation(cartProductRelation);
 		
+		em.persist(cartProductRelation);
+		
+		em.flush();
+		
 		//when
-		CartResponseDTO actualCartResponseDTO = cartService.getCart("qkrtkdwns3410@gmail.com");
+		CartResponseDTO actualCartResponseDTO = cartService.getCart(memberEmail);
 		
 		//then
+		assertThat(actualCartResponseDTO).as("CartResponseDTO는 null이 아니어야 한다")
+			.isNotNull();
 		
+		assertThat(actualCartResponseDTO.getProducts()).as("제품 목록은 null이 아니고 비어있지 않아야 한다")
+			.isNotNull()
+			.isNotEmpty();
+		
+		assertAll("CartResponseDTO 검증",
+			() -> assertThat(actualCartResponseDTO.getUserId())
+				.as("사용자 ID가 예상한 값과 일치해야 한다")
+				.isEqualTo(memberEmail),
+			
+			() -> assertThat(actualCartResponseDTO.getCreatedDate())
+				.as("생성 날짜가 NOW 이후여야 한다")
+				.isAfter(NOW),
+			
+			() -> assertThat(actualCartResponseDTO.getProducts().get(0).getProductId())
+				.as("첫 번째 제품의 ID가 예상한 값과 일치해야 한다")
+				.isEqualTo(product.getId()),
+			
+			() -> assertThat(actualCartResponseDTO.getProducts().get(0).getProductQuantity())
+				.as("첫 번째 제품의 수량이 예상한 값과 일치해야 한다")
+				.isEqualTo(cartProductRelation.getProductQuantity())
+		);
+	}
+	
+	@Test
+	@DisplayName("사용자 이름 단건 조회 서비스 - 장바구니 생성 내역 자체가 없는 경우 -  NotFoundException 발생")
+	void When_getCart_Then_returnEmptyCartResponseDTO() {
+		//given
+		final String memberEmail = "akdjladjajsjadaj";
+		
+		//when
+		assertThatThrownBy(() -> cartService.getCart(memberEmail))
+			//then
+			.isInstanceOf(NotFoundException.class)
+			.hasMessage(ErrorCode.CART_NOT_FOUND.getMessage());
 	}
 }

--- a/src/test/java/com/psj/itembrowser/cart/service/CartSelectWithDBServiceTest.java
+++ b/src/test/java/com/psj/itembrowser/cart/service/CartSelectWithDBServiceTest.java
@@ -1,0 +1,78 @@
+package com.psj.itembrowser.cart.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import com.psj.itembrowser.cart.domain.dto.response.CartResponseDTO;
+import com.psj.itembrowser.cart.domain.entity.CartEntity;
+import com.psj.itembrowser.cart.domain.entity.CartProductRelationEntity;
+import com.psj.itembrowser.cart.mapper.CartMapper;
+import com.psj.itembrowser.cart.persistance.CartPersistence;
+import com.psj.itembrowser.cart.persistance.CartRepository;
+import com.psj.itembrowser.config.annotation.ServiceWithDBTest;
+import com.psj.itembrowser.product.domain.entity.ProductEntity;
+
+/**
+ * packageName    : com.psj.itembrowser.user.cart.service.impl fileName       : CartServiceImplTest
+ * author         : ipeac date           : 2023-10-16 description    :
+ * =========================================================== DATE              AUTHOR NOTE
+ * ----------------------------------------------------------- 2023-10-16        ipeac       최초 생성
+ */
+
+@ServiceWithDBTest
+class CartSelectWithDBServiceTest {
+	
+	@Autowired
+	private TestEntityManager em;
+	
+	@Autowired
+	private CartRepository cartRepository;
+	
+	@Mock
+	private CartMapper cartMapper;
+	
+	private CartPersistence cartPersistence;
+	
+	private CartService cartService;
+	
+	@BeforeEach
+	void setUp() {
+		cartPersistence = new CartPersistence(cartMapper, cartRepository);
+		cartService = new CartService(cartPersistence, cartMapper);
+	}
+	
+	@Test
+	@DisplayName("사용자 이름 단건 조회 서비스 - 정상 처리")
+	void test1() {
+		//given
+		CartEntity cart = CartEntity.builder()
+			.userEmail("qkrtkdwns3410@gmail.com")
+			.build();
+		
+		ProductEntity product = ProductEntity.builder()
+			.name("섬유유연제")
+			.unitPrice(1000)
+			.build();
+		
+		em.persist(cart);
+		em.persist(product);
+		
+		CartProductRelationEntity cartProductRelation = CartProductRelationEntity.builder()
+			.cartId(cart.getId())
+			.productId(product.getId())
+			.product(product)
+			.build();
+		
+		cart.addCartProductRelation(cartProductRelation);
+		
+		//when
+		CartResponseDTO actualCartResponseDTO = cartService.getCart("qkrtkdwns3410@gmail.com");
+		
+		//then
+		
+	}
+}

--- a/src/test/java/com/psj/itembrowser/cart/service/CartSelectWithDBServiceTest.java
+++ b/src/test/java/com/psj/itembrowser/cart/service/CartSelectWithDBServiceTest.java
@@ -76,7 +76,6 @@ class CartSelectWithDBServiceTest {
 		CartProductRelationEntity cartProductRelation = CartProductRelationEntity.builder()
 			.cartId(cart.getId())
 			.productId(product.getId())
-			.product(product)
 			.build();
 		
 		cart.addCartProductRelation(cartProductRelation);
@@ -150,7 +149,6 @@ class CartSelectWithDBServiceTest {
 		CartProductRelationEntity cartProductRelation = CartProductRelationEntity.builder()
 			.cartId(cart.getId())
 			.productId(product.getId())
-			.product(product)
 			.build();
 		
 		cart.addCartProductRelation(cartProductRelation);

--- a/src/test/java/com/psj/itembrowser/cart/service/CartServiceTest.java
+++ b/src/test/java/com/psj/itembrowser/cart/service/CartServiceTest.java
@@ -1,4 +1,4 @@
-package com.psj.itembrowser.cart.service.impl;
+package com.psj.itembrowser.cart.service;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -25,7 +25,6 @@ import com.psj.itembrowser.cart.domain.vo.Cart;
 import com.psj.itembrowser.cart.domain.vo.CartProductRelation;
 import com.psj.itembrowser.cart.mapper.CartMapper;
 import com.psj.itembrowser.cart.persistance.CartPersistence;
-import com.psj.itembrowser.cart.service.CartService;
 import com.psj.itembrowser.product.domain.vo.Product;
 import com.psj.itembrowser.security.common.exception.NotFoundException;
 

--- a/src/test/java/com/psj/itembrowser/config/annotation/ServiceWithDBTest.java
+++ b/src/test/java/com/psj/itembrowser/config/annotation/ServiceWithDBTest.java
@@ -12,8 +12,8 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
+import com.psj.itembrowser.config.TestQdslConfig;
 import com.psj.itembrowser.security.common.config.audit.JpaAuditingConfiguration;
-import com.psj.itembrowser.security.common.config.querydsl.QuerydslConfig;
 
 /**
  *packageName    : com.psj.itembrowser.config.annotation
@@ -31,7 +31,7 @@ import com.psj.itembrowser.security.common.config.querydsl.QuerydslConfig;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @AutoConfigureTestDatabase(replace = ANY)
-@Import({QuerydslConfig.class, JpaAuditingConfiguration.class})
+@Import({TestQdslConfig.class, JpaAuditingConfiguration.class})
 @DataJpaTest
 @ActiveProfiles("test")
 public @interface ServiceWithDBTest {

--- a/src/test/java/com/psj/itembrowser/config/annotation/ServiceWithDBTest.java
+++ b/src/test/java/com/psj/itembrowser/config/annotation/ServiceWithDBTest.java
@@ -12,8 +12,8 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
-import com.psj.itembrowser.config.TestQueryDslConfig;
 import com.psj.itembrowser.security.common.config.audit.JpaAuditingConfiguration;
+import com.psj.itembrowser.security.common.config.querydsl.QuerydslConfig;
 
 /**
  *packageName    : com.psj.itembrowser.config.annotation
@@ -31,7 +31,7 @@ import com.psj.itembrowser.security.common.config.audit.JpaAuditingConfiguration
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @AutoConfigureTestDatabase(replace = ANY)
-@Import({TestQueryDslConfig.class, JpaAuditingConfiguration.class})
+@Import({QuerydslConfig.class, JpaAuditingConfiguration.class})
 @DataJpaTest
 @ActiveProfiles("test")
 public @interface ServiceWithDBTest {


### PR DESCRIPTION
## 제목
[PR] 장바구니 단건 조회 관련 마이그레이션 및 중간테이블 Product 와의 연관관계 제거

## 설명
1. 장바구니 중간 테이블과 ProductEntity 간의 연관관계를 제거했습니다. ( DDD 관점 )
2. 단건 조회 마이그레이션 수행

## 변경 유형
- [ ] 새로운 기능
- [ ] 버그 수정
- [x] 중대한 변경
- [ ] 기술적 개선

## 테스팅
1. 단건 조회 성공 실패 테스트 코드 4건 수정

## 체크리스트
- [ ] 내 코드는 이 프로젝트의 코드 스타일을 따릅니다.
- [ ] 필요한 경우 문서를 추가했습니다(해당되는 경우).
- [ ] 다른 풀 리퀘스트가 같은 업데이트/변경에 대해 없는지 확인했습니다.

## 추가 메모
리뷰에 도움이 될 수 있는 다른 맥락이나 메모를 추가해주세요.

## TODO
주문 생성 마이그레이션 수행